### PR TITLE
Commands can determine app in standard manner.

### DIFF
--- a/commands/washtub/init.js
+++ b/commands/washtub/init.js
@@ -9,7 +9,6 @@ let { ensure_app, ensure_token } = require('../../lib/cli-util')
 function * run(context, heroku) {
   let source = context.args.database || 'DATABASE_URL'
   let app = ensure_app(context)
-
   let addons = yield heroku.get(`/apps/${app}/addons`)
   let db_addon = _.find(addons, (o) => { return _.includes(o.config_vars, source) })
 
@@ -35,13 +34,10 @@ module.exports = {
   `,
 
   needsAuth: true,
+  needsApp: true,
 
   args: [
     {name: 'database', optional: true, description: 'The database to add to Washtub, defaults to DATABASE_URL'}
-  ],
-
-  flags: [
-    {name: 'app', char: 'a', hasValue: true, description: 'the Heroku app to use'},
   ],
 
   run: cli.command(co.wrap(run))

--- a/commands/washtub/list.js
+++ b/commands/washtub/list.js
@@ -39,10 +39,7 @@ module.exports = {
   `,
 
   needsAuth: true,
-
-  flags: [
-    { name: 'app', char: 'a', hasValue: true, description: 'the Heroku app to use' },
-  ],
+  needsApp: true,
 
   run: cli.command(co.wrap(run))
 }

--- a/commands/washtub/pull.js
+++ b/commands/washtub/pull.js
@@ -49,14 +49,11 @@ module.exports = {
   `,
 
   needsAuth: true,
+  needsApp: true,
 
   args: [
     { name: 'wash', optional: false, description: 'The wash number of the wash to pull' },
     { name: 'target', optional: false, description: 'The target DB to load washed data into' }
-  ],
-
-  flags: [
-    { name: 'app', char: 'a', hasValue: true, description: 'the Heroku app to use' },
   ],
 
   run: cli.command(co.wrap(run))

--- a/commands/washtub/wash.js
+++ b/commands/washtub/wash.js
@@ -71,14 +71,11 @@ module.exports = {
   `,
 
   needsAuth: true,
+  needsApp: true,
 
   args: [
     { name: 'backup', optional: false, description: 'The bakcup_id of a backup to load and wash' },
     { name: 'target', optional: false, description: 'The target DB to load washed data into' }
-  ],
-
-  flags: [
-    { name: 'app', char: 'a', hasValue: true, description: 'the Heroku app to use' },
   ],
 
   run: cli.command(co.wrap(run))

--- a/lib/cli-util.js
+++ b/lib/cli-util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports.ensure_app = function(context) {
-  let app = context.flags.app || process.env.HEROKU_APP
+  let app = context.flags.app || process.env.HEROKU_APP || context.app
 
   if(! app) {
     throw new Error("Please supply heroku app via --app or HEROKU_APP environment variable.")


### PR DESCRIPTION
Just like all other heroku command line tools,

--app and -a take precedent.
Next HEROKU_APP environment variable is consulted.
If that's not present, and there's a remote called heroku, that
is used to determine the app name.