### PR TITLE
Improve response messages from CLI.

### DIFF
--- a/commands/washtub/pull.js
+++ b/commands/washtub/pull.js
@@ -14,10 +14,14 @@ function * run(context, heroku) {
   let token = ensure_token(config, app)
   let washtub_client = new WashtubWash({ auth_token: token })
   let response = yield washtub_client.download_url(wash)
-  let download_url = response.data
+  if(response.status == 'ok') {
+    let download_url = response.data
 
-  cli.action.start(`Pulling into database ${database}`)
-  load_wash(download_url, database)
+    cli.action.start(`Pulling into database ${database}`)
+    load_wash(download_url, database)
+  } else {
+    cli.error(`There was a problem pulling your wash: ${response.data}`)
+  }
 }
 
 module.exports = {

--- a/lib/cli-util.js
+++ b/lib/cli-util.js
@@ -14,7 +14,7 @@ module.exports.ensure_token = function(configs, app) {
   let token = configs.WASHTUB_TOKEN
 
   if(! token) {
-    throw new Error(`Unable to retrieve the washtub api token from ${app}`)
+    throw new Error(`Unable to retrieve WASHTUB_TOKEN from ${app}`)
   }
 
   return token

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heroku-washtub",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Clean your production data for development use with Washtub!",
   "keywords": "data anonymization privacy compliance",
   "main": "index.js",


### PR DESCRIPTION
Pull and list have more explanatory messagees, displaying
messages from api responses.

Note washtub-core PR98 and PR99 need to be deployed for this
to work properly.